### PR TITLE
Support for function scope (unityweb)

### DIFF
--- a/src/similar_function_eliminator.js
+++ b/src/similar_function_eliminator.js
@@ -193,6 +193,15 @@ SimilarFunctionEliminator.prototype.getAsmAst = function(ast) {
         asmAst = expression.right.body;
         break;
       }
+
+      // Look for function scope
+      if ( expression.type === 'FunctionExpression' &&
+           expression.body.body[0].type === 'ExpressionStatement' &&
+           expression.body.body[0].expression.type === 'Literal' &&
+           expression.body.body[0].expression.value === 'use asm') {
+        asmAst = expression.body;
+        break;  
+      }
     }
   }
 


### PR DESCRIPTION
Unity webgl builder, repack emscripten output into function scope, like this:
```javascript
(function(global,env,buffer) {
"use asm";var a=new global.Int8Array(buffer);var b=new global.Int16Array(buffer);var c=new global.Int32Array(buffer);var d=new global.Uint8Array(buffer);var e=new global.Uint16Array(buffer);var f=new global.Uint32Array(buffer);var g=new global.Float32Array(buffer);var h=new global.Float64Array(buffer);var i=env.DYNAMICTOP_PTR|0;var j=env.tempDoublePtr|0;var k=env.ABORT|0;var l=env.STACKTOP|0;var m=env.STACK_MAX|0;var n=env.cttz_i8|0;var o=0;var p=0;var q=0;var r=0;var s=global.NaN,t=global.Infinity;var u=0,v=0,w=0,x=0,y=0.0;var z=0
```

In this PR I simply look for function scope, and use it body as asmAst if body starts with 'use asm'. With this PR you can use SFE over unityweb files